### PR TITLE
sensor: Add sensor spec files for webserver

### DIFF
--- a/sensor_specs/README.md
+++ b/sensor_specs/README.md
@@ -1,0 +1,6 @@
+## Where to put sensor spec files?
+/etc/mini-air-quality/sensor-spec
+
+## Other actions required
+None
+

--- a/sensor_specs/README.md
+++ b/sensor_specs/README.md
@@ -1,6 +1,8 @@
-## Where to put sensor spec files?
-/etc/mini-air-quality/sensor-spec
+## Where to put files?
+- *.yaml -> /etc/mini-air-quality/sensor-spec/
+- set_envs.py -> don't put on the image, only to generate config
+- sensors_config.ini -> /etc/mini-air-quality/
+- envs.lock -> /etc/mini-air-quality/
 
 ## Other actions required
-None
-
+sensors_config.ini and envs.lock must have 766 access mask.

--- a/sensor_specs/humidity_sensor.yaml
+++ b/sensor_specs/humidity_sensor.yaml
@@ -1,0 +1,12 @@
+sensors:
+  - name: Humidity sensor
+    model: DHT22
+    measure_unit: "%"
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: HUMIDITY_DHT22_FREQ
+    active: true

--- a/sensor_specs/particles_sensor.yaml
+++ b/sensor_specs/particles_sensor.yaml
@@ -1,0 +1,34 @@
+sensors:
+  - name: Particle sensor PM1.0
+    model: PMSA003-C
+    measure_unit: μg/m³
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: PARTICLE_PM1_PMSA003-C_FREQ
+    active: true
+  - name: Particle sensor PM2.5
+    model: PMSA003-C
+    measure_unit: μg/m³
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: PARTICLE_PM25_PMSA003-C_FREQ
+    active: true
+  - name: Particle sensor PM10
+    model: PMSA003-C
+    measure_unit: μg/m³
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: PARTICLE_PM10_PMSA003-C_FREQ
+    active: true

--- a/sensor_specs/pressure_sensor.yaml
+++ b/sensor_specs/pressure_sensor.yaml
@@ -1,0 +1,12 @@
+sensors:
+  - name: Pressure sensor
+    model: BMP280
+    measure_unit: hPa
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: PRESSURE_BMP280_FREQ
+    active: true

--- a/sensor_specs/sensors_config.ini
+++ b/sensor_specs/sensors_config.ini
@@ -1,0 +1,9 @@
+[sensors_config]
+humidity_dht22_freq = 2
+particle_pm1_pmsa003-c_freq = 2
+particle_pm25_pmsa003-c_freq = 2
+particle_pm10_pmsa003-c_freq = 2
+pressure_bmp280_freq = 2
+temperature_bmp280_freq = 2
+temperature_dht22_freq = 2
+

--- a/sensor_specs/set_envs.py
+++ b/sensor_specs/set_envs.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import os
+import yaml
+import configparser
+
+'''
+Set default measurement frequency for each sensor. Not included in the image.
+Used to generate sensors_config.ini.
+'''
+
+SPECS_PATH = "/etc/mini-air-quality/sensor-spec/"
+LOCKFILE = "/etc/mini-air-quality/sensor-spec/envs.lock"
+CONFIG_FILE = "/etc/mini-air-quality/sensors_config.ini"
+
+if __name__ == '__main__':
+    spec_filenames = list(filter(lambda file: "yaml" in file, os.listdir(SPECS_PATH)))
+    config = configparser.ConfigParser()
+    config.add_section("sensors_config")
+
+    for spec_filename in spec_filenames:
+        with open(SPECS_PATH+spec_filename, 'r') as spec_file:
+            sensors_data= yaml.load(spec_file, Loader=yaml.SafeLoader)
+            for sensor in sensors_data['sensors']:
+                sensor_env = sensor['env_name'].upper()
+                sensor_default_measure_freq = str(sensor['default_measure_freq'])
+                config.set("sensors_config", sensor_env, sensor_default_measure_freq)
+    
+    with open(CONFIG_FILE, 'w') as config_file:
+        config.write(config_file)

--- a/sensor_specs/temperature_sensor.yaml
+++ b/sensor_specs/temperature_sensor.yaml
@@ -1,0 +1,23 @@
+sensors:
+  - name: Temperature sensor
+    model: BMP280
+    measure_unit: °C
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: TEMPERATURE_BMP280_FREQ
+    active: false
+  - name: Temperature sensor
+    model: DHT22
+    measure_unit: °C
+    measure_freq_unit: s # Seconds
+    measure_freq_caps: #TODO: Update caps when discussed
+      - 1
+      - 2
+      - 3
+    default_measure_freq: 2
+    env_name: TEMPERATURE_DHT22_FREQ
+    active: true


### PR DESCRIPTION
Feature sensor spec files
They will be used for webserver to display capabilities of the particular sensor to allow measure frequency adjustment.

Discussion required if we will use temp sensors, if not then which one will be used.

Signed-off-by: punfil <wojtek.panfil@hotmail.com>